### PR TITLE
Add static form to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,21 @@
   </head>
 
   <body>
+    <!-- Hidden Netlify form template for detection -->
+    <form name="contact" netlify netlify-honeypot="bot-field" hidden>
+      <input type="text" name="name" />
+      <input type="email" name="email" />
+      <input type="tel" name="phone" />
+      <input type="text" name="postal_code" />
+      <input type="text" name="callback_time" />
+      <textarea name="message"></textarea>
+      <input type="text" name="gclid" />
+      <p hidden>
+        <label>
+          Don't fill this out: <input name="bot-field" />
+        </label>
+      </p>
+    </form>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>


### PR DESCRIPTION
Add a static HTML form to `index.html` to ensure Netlify can detect the form fields. This mirrors a previous successful solution for form detection.